### PR TITLE
Added pyproject with minimum dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "troppo"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.rst"
+requires-python = ">=3.9"
+dependencies = [
+    "cobamp>=0.2.1",
+    "cobra>=0.24.0",
+    "xlrd>=1.2.0"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Vítor Vieira"}
 ]
 readme = "README.rst"
-license = {file = "LICENSE"}
+license = {file = "LICENSE.txt"}
 requires-python = ">=3.9"
 dependencies = [
     "cobamp>=0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ authors = [
 readme = "README.rst"
 license = {file = "LICENSE"}
 requires-python = ">=3.9"
+dependencies = [
+    "cobamp>=0.2.1",
+    "cobra>=0.24.0",
+    "xlrd>=1.2.0"
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
@@ -26,14 +31,5 @@ Repository = "https://github.com/BioSystemsUM/troppo/"
 Issues = "https://github.com/BioSystemsUM/troppo/issues"
 
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-package-dir = { "" = "src" }
-packages = { find = "src" }
-install_requires = [
-    "cobamp>=0.2.1",
-    "cobra>=0.24.0",
-    "xlrd>=1.2.0"
-]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,36 @@
 [project]
 name = "troppo"
 version = "0.1.0"
-description = "Add your description here"
+description = "Constraint-based modeling framework for the enumeration of pathway analysis concepts"
+authors = [
+    {name = "Jorge Ferreira", email = "jorge.ferreira@ceb.uminho.pt"},
+    {name = "Vítor Vieira"}
+]
 readme = "README.rst"
+license = {file = "LICENSE"}
+homepage = "https://github.com/BioSystemsUM/troppo"
 requires-python = ">=3.9"
-dependencies = [
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3.5",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "'Topic :: Software Development :: Libraries :: Python Modules"'
+]
+
+
+[project.urls]
+Documentation = "https://github.com/BioSystemsUM/troppo/blob/main/README.rst"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+packages = { find = "src" }
+install_requires = [
     "cobamp>=0.2.1",
     "cobra>=0.24.0",
     "xlrd>=1.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 ]
 readme = "README.rst"
 license = {file = "LICENSE"}
-homepage = "https://github.com/BioSystemsUM/troppo"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -21,7 +20,10 @@ classifiers = [
 
 
 [project.urls]
-Documentation = "https://github.com/BioSystemsUM/troppo/blob/main/README.rst"
+Homepage = "https://github.com/BioSystemsUM/troppo"
+Documentation = "http://troppo-bisbi.readthedocs.io/"
+Repository = "https://github.com/BioSystemsUM/troppo/"
+Issues = "https://github.com/BioSystemsUM/troppo/issues"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "troppo"
 version = "0.1.0"
-description = "Constraint-based modeling framework for the enumeration of pathway analysis concepts"
+description = "Reconstruction algorithms for Python"
 authors = [
     {name = "Jorge Ferreira", email = "jorge.ferreira@ceb.uminho.pt"},
     {name = "Vítor Vieira"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3.5",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "'Topic :: Software Development :: Libraries :: Python Modules"'
+    "'Topic :: Software Development :: Libraries :: Python Modules"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ dependencies = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3.5",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "'Topic :: Software Development :: Libraries :: Python Modules"
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
 
 


### PR DESCRIPTION
The current implementation (requirements.txt) has fixed dependency versions. This makes it impossible to update to newer packages if Troppo is also required. This pull request loosens the fixes requirements and instead uses minimum requirements

This isn't a perfect fix (ideally, a maximum version would be included as well), but I could not get the tests to work properly to determine what maximum versions for each dependency should be set to.