### PR TITLE
Add GIMME generic type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "troppo"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.rst"
+requires-python = ">=3.9"
+dependencies = [
+    "cobamp>=0.2.1",
+    "cobra>=0.24.0",
+    "xlrd>=1.2.0"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Vítor Vieira"}
 ]
 readme = "README.rst"
-license = {file = "LICENSE"}
+license = {file = "LICENSE.txt"}
 requires-python = ">=3.9"
 dependencies = [
     "cobamp>=0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ authors = [
 readme = "README.rst"
 license = {file = "LICENSE"}
 requires-python = ">=3.9"
+dependencies = [
+    "cobamp>=0.2.1",
+    "cobra>=0.24.0",
+    "xlrd>=1.2.0"
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
@@ -26,14 +31,5 @@ Repository = "https://github.com/BioSystemsUM/troppo/"
 Issues = "https://github.com/BioSystemsUM/troppo/issues"
 
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-package-dir = { "" = "src" }
-packages = { find = "src" }
-install_requires = [
-    "cobamp>=0.2.1",
-    "cobra>=0.24.0",
-    "xlrd>=1.2.0"
-]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,36 @@
 [project]
 name = "troppo"
 version = "0.1.0"
-description = "Add your description here"
+description = "Constraint-based modeling framework for the enumeration of pathway analysis concepts"
+authors = [
+    {name = "Jorge Ferreira", email = "jorge.ferreira@ceb.uminho.pt"},
+    {name = "Vítor Vieira"}
+]
 readme = "README.rst"
+license = {file = "LICENSE"}
+homepage = "https://github.com/BioSystemsUM/troppo"
 requires-python = ">=3.9"
-dependencies = [
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3.5",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "'Topic :: Software Development :: Libraries :: Python Modules"'
+]
+
+
+[project.urls]
+Documentation = "https://github.com/BioSystemsUM/troppo/blob/main/README.rst"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+packages = { find = "src" }
+install_requires = [
     "cobamp>=0.2.1",
     "cobra>=0.24.0",
     "xlrd>=1.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 ]
 readme = "README.rst"
 license = {file = "LICENSE"}
-homepage = "https://github.com/BioSystemsUM/troppo"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -21,7 +20,10 @@ classifiers = [
 
 
 [project.urls]
-Documentation = "https://github.com/BioSystemsUM/troppo/blob/main/README.rst"
+Homepage = "https://github.com/BioSystemsUM/troppo"
+Documentation = "http://troppo-bisbi.readthedocs.io/"
+Repository = "https://github.com/BioSystemsUM/troppo/"
+Issues = "https://github.com/BioSystemsUM/troppo/issues"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "troppo"
 version = "0.1.0"
-description = "Constraint-based modeling framework for the enumeration of pathway analysis concepts"
+description = "Reconstruction algorithms for Python"
 authors = [
     {name = "Jorge Ferreira", email = "jorge.ferreira@ceb.uminho.pt"},
     {name = "Vítor Vieira"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3.5",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "'Topic :: Software Development :: Libraries :: Python Modules"'
+    "'Topic :: Software Development :: Libraries :: Python Modules"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ dependencies = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3.5",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "'Topic :: Software Development :: Libraries :: Python Modules"
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
 
 

--- a/src/troppo/methods/base.py
+++ b/src/troppo/methods/base.py
@@ -14,7 +14,7 @@ class ContextSpecificModelReconstructionAlgorithm(object):
 	__metaclass__ = abc.ABCMeta
 
 	@abc.abstractmethod
-	def __init__(self, S, lb, ub, properties):
+	def __init__(self, S, lb, ub, properties, solver):
 		pass
 
 	@abc.abstractmethod

--- a/src/troppo/methods/base.py
+++ b/src/troppo/methods/base.py
@@ -14,7 +14,7 @@ class ContextSpecificModelReconstructionAlgorithm(object):
 	__metaclass__ = abc.ABCMeta
 
 	@abc.abstractmethod
-	def __init__(self, S, lb, ub, properties, solver):
+	def __init__(self, S, lb, ub, properties):
 		pass
 
 	@abc.abstractmethod

--- a/src/troppo/methods/reconstruction/gimme.py
+++ b/src/troppo/methods/reconstruction/gimme.py
@@ -210,16 +210,16 @@ class GIMMEProperties(PropertiesReconstruction):
     ):
         new_mandatory = {
             "exp_vector": lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
-            "preprocess": lambda x: isinstance(x, bool) or x is None,
-            "objectives": lambda x: type(x) in [list, tuple, ndarray],
+            "preprocess": lambda x: isinstance(x, (bool, None)),
+            "objectives": lambda x: isinstance(x, (list, tuple, npt.NDArray)),
             "reaction_ids": lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
             "metabolite_ids": lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
         }
 
         new_optional = {
-            "obj_frac": lambda x: type(x) in [ndarray, list, tuple, float],
-            "flux_threshold": lambda x: isinstance(x, float) or x is None,
-            "solver": lambda x: isinstance(x, str) or x is None,
+            "obj_frac": lambda x: isinstance(x, (ndarray, list, tuple, float)),
+            "flux_threshold": lambda x: isinstance(x, (float, None)),
+            "solver": lambda x: isinstance(x, (str, None)),
         }
         super().__init__()
 

--- a/src/troppo/methods/reconstruction/gimme.py
+++ b/src/troppo/methods/reconstruction/gimme.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
+from typing import Iterable, Mapping, Optional, Sequence, Union
 
 import numpy as np
+import numpy.typing as npt
 from cobamp.core.models import ConstraintBasedModel
 from cobamp.core.optimization import Solution
 from numpy import array, ndarray

--- a/src/troppo/methods/reconstruction/gimme.py
+++ b/src/troppo/methods/reconstruction/gimme.py
@@ -64,8 +64,13 @@ class GIMMEModel(ConstraintBasedModel):
                 exp_vector_n[rxmap] = val
         return exp_vector_n
 
-    def optimize_gimme(self, exp_vector: list, objectives: list or tuple, obj_frac: list or tuple or float = 0.9, flux_thres: float = None):
+    def optimize_gimme(
+        self,
+        exp_vector: Iterable[float],
+        objectives: Iterable[Mapping[int, int]],
+        obj_frac: Union[Iterable[float], float] = 0.9,
         flux_thres: Optional[float] = None,
+    ):
         """
         Optimize the GIMME model.
 
@@ -74,7 +79,7 @@ class GIMMEModel(ConstraintBasedModel):
         exp_vector: list
             A list of expression values for each reaction in the GIMME model.
         objectives: list or tuple
-            A list of dictionaries that define the objectives of the GIMME model.
+            A list of dictionaries where keys are reaction indices and values define the objectives of the GIMME model.
         obj_frac: list or tuple or float
             A list of fractions that define the lower bounds of the objectives. If a float is given, the same fraction
             is used for all objectives.
@@ -194,9 +199,9 @@ class GIMMEProperties(PropertiesReconstruction):
 
     def __init__(
         self,
-        exp_vector: list,
-        objectives: list or tuple,
-        obj_frac: list or tuple or float = 0.9,
+        exp_vector: Iterable[float],
+        objectives: Sequence,
+        obj_frac: Union[Iterable[float], float] = 0.9,
         preprocess: bool = False,
         flux_threshold: Optional[float] = None,
         solver: Optional[str] = None,
@@ -230,7 +235,7 @@ class GIMMEProperties(PropertiesReconstruction):
         self["flux_threshold"] = 1e-4 if flux_threshold is None else flux_threshold
 
     @staticmethod
-    def from_integrated_scores(scores: list, **kwargs):
+    def from_integrated_scores(scores: Iterable[float], **kwargs):
         """
         Create GIMMEProperties from integrated scores
 

--- a/src/troppo/methods/reconstruction/gimme.py
+++ b/src/troppo/methods/reconstruction/gimme.py
@@ -30,7 +30,7 @@ class GIMMEModel(ConstraintBasedModel):
 
     """
 
-    def __init__(self, cbmodel: ConstraintBasedModel, solver: str or None = None):
+    def __init__(self, cbmodel: ConstraintBasedModel, solver: Optional[str] = None):
         self.cbmodel = cbmodel
         if not self.cbmodel.model:
             self.cbmodel.initialize_optimizer()
@@ -65,6 +65,7 @@ class GIMMEModel(ConstraintBasedModel):
         return exp_vector_n
 
     def optimize_gimme(self, exp_vector: list, objectives: list or tuple, obj_frac: list or tuple or float = 0.9, flux_thres: float = None):
+        flux_thres: Optional[float] = None,
         """
         Optimize the GIMME model.
 
@@ -197,10 +198,10 @@ class GIMMEProperties(PropertiesReconstruction):
         objectives: list or tuple,
         obj_frac: list or tuple or float = 0.9,
         preprocess: bool = False,
-        flux_threshold: float = None,
-        solver: str = None,
-        reaction_ids: list = None,
-        metabolite_ids: list = None,
+        flux_threshold: Optional[float] = None,
+        solver: Optional[str] = None,
+        reaction_ids: Optional[Iterable[str]] = None,
+        metabolite_ids: Optional[Iterable[str]] = None,
     ):
         new_mandatory = {
             "exp_vector": lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),

--- a/src/troppo/methods/reconstruction/gimme.py
+++ b/src/troppo/methods/reconstruction/gimme.py
@@ -1,9 +1,10 @@
-import numpy as np
 from collections import OrderedDict
-from numpy import ndarray, array
 
+import numpy as np
 from cobamp.core.models import ConstraintBasedModel
 from cobamp.core.optimization import Solution
+from numpy import array, ndarray
+
 from troppo.methods.base import ContextSpecificModelReconstructionAlgorithm, PropertiesReconstruction
 
 
@@ -26,6 +27,7 @@ class GIMMEModel(ConstraintBasedModel):
         A dictionary that maps the reactions of the template model to the reactions of the GIMME model.
 
     """
+
     def __init__(self, cbmodel: ConstraintBasedModel, solver: str or None = None):
         self.cbmodel = cbmodel
         if not self.cbmodel.model:
@@ -35,13 +37,12 @@ class GIMMEModel(ConstraintBasedModel):
 
         S = irrev_model.get_stoichiometric_matrix()
         bounds = irrev_model.bounds
-        super().__init__(S, bounds, irrev_model.reaction_names, irrev_model.metabolite_names, solver=solver,
-                         optimizer=True)
+        super().__init__(S, bounds, irrev_model.reaction_names, irrev_model.metabolite_names, solver=solver, optimizer=True)
 
     def __adjust_objective_to_irreversible(self, objective_dict):
         obj_dict = {}
         for k, v in objective_dict.items():
-            irrev_map = self.mapping[self.cbmodel.decode_index(k, 'reaction')]
+            irrev_map = self.mapping[self.cbmodel.decode_index(k, "reaction")]
             if isinstance(irrev_map, (list, tuple)):
                 for i in irrev_map:
                     obj_dict[i] = v
@@ -50,7 +51,9 @@ class GIMMEModel(ConstraintBasedModel):
         return obj_dict
 
     def __adjust_expression_vector_to_irreversible(self, exp_vector):
-        exp_vector_n = np.zeros(len(self.reaction_names), )
+        exp_vector_n = np.zeros(
+            len(self.reaction_names),
+        )
         for rxn, val in enumerate(exp_vector):
             rxmap = self.mapping[rxn]
             if isinstance(rxmap, tuple):
@@ -59,8 +62,7 @@ class GIMMEModel(ConstraintBasedModel):
                 exp_vector_n[rxmap] = val
         return exp_vector_n
 
-    def optimize_gimme(self, exp_vector: list, objectives: list or tuple, obj_frac: list or tuple or float = 0.9,
-                       flux_thres: float = None):
+    def optimize_gimme(self, exp_vector: list, objectives: list or tuple, obj_frac: list or tuple or float = 0.9, flux_thres: float = None):
         """
         Optimize the GIMME model.
 
@@ -91,8 +93,7 @@ class GIMMEModel(ConstraintBasedModel):
 
         objective_values = list(map(find_objective_value, objectives_irr))
 
-        gimme_model_objective = array(
-            [flux_thres - exp_vector_irr[i] if -1 < exp_vector_irr[i] < flux_thres else 0 for i in range(N)])
+        gimme_model_objective = array([flux_thres - exp_vector_irr[i] if -1 < exp_vector_irr[i] < flux_thres else 0 for i in range(N)])
 
         objective_lbs = np.zeros(len(self.reaction_names))
         for ov, obj in zip(objective_values, objectives_irr):
@@ -126,17 +127,16 @@ class GIMMESolution(Solution):
         A dictionary that maps the reactions of the template model to the reactions of the GIMME model.
 
     """
+
     def __init__(self, sol, exp_vector, var_names, mapping=None):
         self.exp_vector = exp_vector
         gimme_solution = sol.x()
         if mapping:
-            gimme_solution = [max(gimme_solution[array(new)]) if isinstance(new, (tuple, list)) else gimme_solution[new]
-                              for orig, new
-                              in mapping.items()]
+            gimme_solution = [
+                max(gimme_solution[array(new)]) if isinstance(new, (tuple, list)) else gimme_solution[new] for orig, new in mapping.items()
+            ]
         super().__init__(
-            value_map=OrderedDict([(k, v) for k, v in zip(var_names, gimme_solution)]),
-            status=sol.status(),
-            objective_value=sol.objective_value()
+            value_map=OrderedDict([(k, v) for k, v in zip(var_names, gimme_solution)]), status=sol.status(), objective_value=sol.objective_value()
         )
 
     def get_reaction_activity(self, flux_threshold: float):
@@ -188,31 +188,43 @@ class GIMMEProperties(PropertiesReconstruction):
         List of metabolite ids
 
     """
-    def __init__(self, exp_vector: list, objectives: list or tuple, obj_frac: list or tuple or float = 0.9,
-                 preprocess: bool = False, flux_threshold: float = None, solver: str = None, reaction_ids: list = None,
-                 metabolite_ids: list = None):
-        new_mandatory = {
-            'exp_vector': lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
-            'preprocess': lambda x: isinstance(x, bool) or x is None,
-            'objectives': lambda x: type(x) in [list, tuple, ndarray],
-            'reaction_ids': lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
-            'metabolite_ids': lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray)}
 
-        new_optional = {'obj_frac': lambda x: type(x) in [ndarray, list, tuple, float],
-                        'flux_threshold': lambda x: isinstance(x, float) or x is None,
-                        'solver': lambda x: isinstance(x, str) or x is None}
+    def __init__(
+        self,
+        exp_vector: list,
+        objectives: list or tuple,
+        obj_frac: list or tuple or float = 0.9,
+        preprocess: bool = False,
+        flux_threshold: float = None,
+        solver: str = None,
+        reaction_ids: list = None,
+        metabolite_ids: list = None,
+    ):
+        new_mandatory = {
+            "exp_vector": lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
+            "preprocess": lambda x: isinstance(x, bool) or x is None,
+            "objectives": lambda x: type(x) in [list, tuple, ndarray],
+            "reaction_ids": lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
+            "metabolite_ids": lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
+        }
+
+        new_optional = {
+            "obj_frac": lambda x: type(x) in [ndarray, list, tuple, float],
+            "flux_threshold": lambda x: isinstance(x, float) or x is None,
+            "solver": lambda x: isinstance(x, str) or x is None,
+        }
         super().__init__()
 
         self.add_new_properties(new_mandatory, new_optional)
 
-        self['objectives'] = objectives
-        self['exp_vector'] = exp_vector
-        self['solver'] = solver
-        self['reaction_ids'] = reaction_ids
-        self['metabolite_ids'] = metabolite_ids
-        self['obj_frac'] = obj_frac if isinstance(obj_frac, ndarray) else array([obj_frac] * len(objectives))
-        self['preprocess'] = True if preprocess else False
-        self['flux_threshold'] = 1e-4 if flux_threshold is None else flux_threshold
+        self["objectives"] = objectives
+        self["exp_vector"] = exp_vector
+        self["solver"] = solver
+        self["reaction_ids"] = reaction_ids
+        self["metabolite_ids"] = metabolite_ids
+        self["obj_frac"] = obj_frac if isinstance(obj_frac, ndarray) else array([obj_frac] * len(objectives))
+        self["preprocess"] = True if preprocess else False
+        self["flux_threshold"] = 1e-4 if flux_threshold is None else flux_threshold
 
     @staticmethod
     def from_integrated_scores(scores: list, **kwargs):
@@ -231,7 +243,7 @@ class GIMMEProperties(PropertiesReconstruction):
         GIMMEProperties
 
         """
-        return GIMMEProperties(exp_vector=scores, **{k: v for k, v in kwargs.items() if 'exp_vector' not in k})
+        return GIMMEProperties(exp_vector=scores, **{k: v for k, v in kwargs.items() if "exp_vector" not in k})
 
 
 class GIMME(ContextSpecificModelReconstructionAlgorithm):
@@ -264,6 +276,7 @@ class GIMME(ContextSpecificModelReconstructionAlgorithm):
     gm: GIMMEModel
         GIMME model
     """
+
     properties_class = GIMMEProperties
 
     def __init__(self, S: list, lb: list, ub: list, properties: GIMMEProperties):
@@ -273,9 +286,10 @@ class GIMME(ContextSpecificModelReconstructionAlgorithm):
         self.properties = properties
         self.model = GIMMEModel
         self.sol = None
-        cbm = ConstraintBasedModel(S, list(zip(lb, ub)), reaction_names=self.properties['reaction_ids'],
-                                   metabolite_names=self.properties['metabolite_ids'])
-        self.gm = GIMMEModel(cbm, self.properties['solver'])
+        cbm = ConstraintBasedModel(
+            S, list(zip(lb, ub)), reaction_names=self.properties["reaction_ids"], metabolite_names=self.properties["metabolite_ids"]
+        )
+        self.gm = GIMMEModel(cbm, self.properties["solver"])
 
     def run(self):
         """
@@ -287,10 +301,10 @@ class GIMME(ContextSpecificModelReconstructionAlgorithm):
 
         """
         sol = self.gm.optimize_gimme(
-            exp_vector=self.properties['exp_vector'],
-            objectives=self.properties['objectives'],
-            obj_frac=self.properties['obj_frac'],
-            flux_thres=self.properties['flux_threshold']
+            exp_vector=self.properties["exp_vector"],
+            objectives=self.properties["objectives"],
+            obj_frac=self.properties["obj_frac"],
+            flux_thres=self.properties["flux_threshold"],
         )
         self.sol = sol
-        return sol.get_reaction_activity(self.properties['flux_threshold'])
+        return sol.get_reaction_activity(self.properties["flux_threshold"])

--- a/src/troppo/methods/reconstruction/gimme.py
+++ b/src/troppo/methods/reconstruction/gimme.py
@@ -251,7 +251,12 @@ class GIMMEProperties(PropertiesReconstruction):
         GIMMEProperties
 
         """
-        return GIMMEProperties(exp_vector=scores, **{k: v for k, v in kwargs.items() if "exp_vector" not in k})
+        if "objectives" not in kwargs:
+            raise ValueError("objectives must be provided")
+        kwargs.pop("exp_vector", None)
+        kwargs.pop("objectives", None)
+
+        return GIMMEProperties(exp_vector=scores, objectives=kwargs["objectives"], **kwargs)
 
 
 class GIMME(ContextSpecificModelReconstructionAlgorithm):

--- a/src/troppo/methods/reconstruction/imat.py
+++ b/src/troppo/methods/reconstruction/imat.py
@@ -26,7 +26,7 @@ class IMATProperties(PropertiesReconstruction):
         The epsilon, by default 1
     """
     def __init__(self, exp_vector: np.ndarray or list, exp_thresholds: tuple or list or ndarray,
-                 core: ndarray or list or tuple = None, tolerance: float = 1e-8, epsilon: int or float = 1):
+                 core: ndarray or list or tuple = None, tolerance: float = 1e-8, epsilon: int or float = 1, solver: str = None):
         new_mandatory = {
             'exp_vector': lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
             'exp_thresholds': lambda x: type(x) in (tuple, list, ndarray) and type(x[0]) in [float, int] and type(
@@ -49,6 +49,8 @@ class IMATProperties(PropertiesReconstruction):
             self['tolerance'] = tolerance
         if epsilon:
             self['epsilon'] = epsilon
+        if solver:
+            self["solver"] = solver
 
     @staticmethod
     def from_integrated_scores(scores: list, **kwargs) -> 'IMATProperties':
@@ -213,7 +215,7 @@ class IMAT(ContextSpecificModelReconstructionAlgorithm):
         prefix_maker = lambda cd: list([cd[0] + str(i) for i in range(cd[1])])
         A_names = list(chain(*list(map(prefix_maker, [('V', n), ('Hpos', nh), ('Hneg', nh), ('L', nl)]))))
 
-        lsystem = GenericLinearSystem(S=A, var_types=A_vt, lb=A_lb, ub=A_ub, b_lb=b_lb, b_ub=b_ub, var_names=A_names)
+        lsystem = GenericLinearSystem(S=A, var_types=A_vt, lb=A_lb, ub=A_ub, b_lb=b_lb, b_ub=b_ub, var_names=A_names, solver=self.properties["solver"])
         lso = LinearSystemOptimizer(lsystem)
 
         A_f = np.zeros((A.shape[1]))

--- a/src/troppo/methods/reconstruction/imat.py
+++ b/src/troppo/methods/reconstruction/imat.py
@@ -30,7 +30,8 @@ class IMATProperties(PropertiesReconstruction):
         new_mandatory = {
             'exp_vector': lambda x: isinstance(x, list) and len(x) > 0 or isinstance(x, ndarray),
             'exp_thresholds': lambda x: type(x) in (tuple, list, ndarray) and type(x[0]) in [float, int] and type(
-                x[1]) in [float, int]
+                x[1]) in [float, int],
+            "solver": solver
         }
         new_optional = {
             'core': lambda x: type(x) in [ndarray, list, tuple],
@@ -49,8 +50,6 @@ class IMATProperties(PropertiesReconstruction):
             self['tolerance'] = tolerance
         if epsilon:
             self['epsilon'] = epsilon
-        if solver:
-            self["solver"] = solver
 
     @staticmethod
     def from_integrated_scores(scores: list, **kwargs) -> 'IMATProperties':


### PR DESCRIPTION
This pull request does the following to the [GIMME reconstruction method](https://github.com/BioSystemsUM/troppo/blob/9d7d27334e64c3b16fb8cb4ac65dee81e032031f/src/troppo/methods/reconstruction/gimme.py#L237):

1. Use generic type hints (e.g., [`Iterable`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable), [`Sequence`](https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range) instead of more strict types (e.g., [`list`](https://docs.python.org/3/library/stdtypes.html#list), [`tuple`](https://docs.python.org/3/library/stdtypes.html#tuple))
2. Use [`numpy.typing.NDArray`](https://numpy.org/doc/stable/reference/typing.html) for numpy typing
3. Bumps minimum numpy version to 1.20, as numpy.typing did not exist before this version